### PR TITLE
py/persistentcode: #error while building new port is annoying

### DIFF
--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -773,7 +773,11 @@ void mp_raw_code_save_file(mp_raw_code_t *rc, const char *filename) {
 }
 
 #else
+#if __DEV__
+#pragma message ("mp_raw_code_save_file may not be implemented for this platform")
+#else
 #error mp_raw_code_save_file not implemented for this platform
+#endif
 #endif
 
 #endif // MICROPY_PERSISTENT_CODE_SAVE


### PR DESCRIPTION
adding #define __DEV__ 1  in mpconfigport.h would allow to complete a test build